### PR TITLE
bump ghostscript version to 9.14

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -108,7 +108,7 @@ puts-step "Bundling ImageMagick version $IM_VERSION"
 curl --silent --max-time 60 --location "$IM_URL" | tar xz -C $IM_LOCATION
 
 # Install ghostscript
-GS_VERSION="9.10"
+GS_VERSION="9.14"
 GS_URL="https://${S3_BUCKET}.s3.amazonaws.com/gs-${GS_VERSION}.tar.gz"
 puts-step "Bundling ghostscript version $GS_VERSION"
 curl --silent --max-time 60 --location "$GS_URL" | tar xz -C $IM_LOCATION


### PR DESCRIPTION
Update to ghostscript 9.14. Slight performance improvements over 9.10.
